### PR TITLE
Fix error handler

### DIFF
--- a/internal/pkg/custom_api/controllers/networks.go
+++ b/internal/pkg/custom_api/controllers/networks.go
@@ -3,21 +3,26 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 
 	s "github.com/poc-golang-ns1/internal/pkg/ns1_custom_client/services"
+	e "github.com/poc-golang-ns1/pkg/errors"
 )
 
 // GetAllZones returns all networks from NS1.
 func GetAllNetworks(w http.ResponseWriter, r *http.Request) {
 	client := s.Ns1Client{}
-	ns1Networks := client.Networks.List()
+	ns1Networks, err := client.Networks.List()
 
+	if err != nil {
+		e.ErrorHTTPResponse(w, "Failed to get Networks", 500)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
 	if err := json.NewEncoder(w).Encode(ns1Networks); err != nil {
-		log.Println("Failed to get Networks - ", err)
+		e.ErrorHTTPResponse(w, err.Error(), 500)
+		return
 	}
 }

--- a/internal/pkg/custom_api/controllers/zones.go
+++ b/internal/pkg/custom_api/controllers/zones.go
@@ -3,21 +3,27 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 
 	s "github.com/poc-golang-ns1/internal/pkg/ns1_custom_client/services"
+	e "github.com/poc-golang-ns1/pkg/errors"
 )
 
 // GetAllZones returns all zones from NS1.
 func GetAllZones(w http.ResponseWriter, r *http.Request) {
 	client := s.Ns1Client{}
-	ns1Zones := client.Zones.List()
+	ns1Zones, err := client.Zones.List()
+
+	if err != nil {
+		e.ErrorHTTPResponse(w, "Failed to get Zones", 500)
+		return
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
 	if err := json.NewEncoder(w).Encode(ns1Zones); err != nil {
-		log.Println("Failed to get Zones - ", err)
+		e.ErrorHTTPResponse(w, err.Error(), 500)
+		return
 	}
 }

--- a/internal/pkg/ns1_custom_client/services/dns_networks.go
+++ b/internal/pkg/ns1_custom_client/services/dns_networks.go
@@ -9,9 +9,11 @@ import (
 type NetworksService struct{}
 
 // List returns the list of all networks from NS1.
-func (n NetworksService) List() m.Networks {
+func (n NetworksService) List() (m.Networks, error) {
 	endpoint := "networks"
 	var networks m.Networks
-	u.SendGetRequest(endpoint, &networks)
-	return networks
+	if err := u.SendGetRequest(endpoint, &networks); err != nil {
+		return nil, err
+	}
+	return networks, nil
 }

--- a/internal/pkg/ns1_custom_client/services/dns_zones.go
+++ b/internal/pkg/ns1_custom_client/services/dns_zones.go
@@ -9,9 +9,11 @@ import (
 type ZonesService struct{}
 
 // List returns the list of all zones from NS1.
-func (z ZonesService) List() m.Zones {
+func (z ZonesService) List() (m.Zones, error) {
 	endpoint := "zones"
 	var zones m.Zones
-	u.SendGetRequest(endpoint, &zones)
-	return zones
+	if err := u.SendGetRequest(endpoint, &zones); err != nil {
+		return nil, err
+	}
+	return zones, nil
 }


### PR DESCRIPTION
# [Fix error handler](https://google.com)

## Story
Modified error handler for several functions and added return of 500 response for the endpoint.

## Acceptance criteria
We get a 500 response from the API when the client fails for some reason or if we get a golang error.

## Affected sections
- Custom NS1 API and Client

## Test instructions
- [ ] run the custom api main file within cmd with go run,
- [ ] access the endpoint at http://localhost:8080/networks and http://localhost:8080/zones
- [ ] succesfull output should be displayed
- [ ] Modify the API-KEY in your .env file to use a wrong one.
- [ ] access the endpoint at http://localhost:8080/networks and http://localhost:8080/zones
- [ ] 500 response should be displayed
